### PR TITLE
authorized_keys_d: handle errors in uid/gid Atoi()

### DIFF
--- a/src/authorized_keys_d/authorized_keys_d.go
+++ b/src/authorized_keys_d/authorized_keys_d.go
@@ -102,8 +102,14 @@ func asUser(usr *user.User, f func() error) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	asu, _ := strconv.Atoi(usr.Uid)
-	asg, _ := strconv.Atoi(usr.Gid)
+	asu, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return fmt.Errorf("invalid uid: %v", err)
+	}
+	asg, err := strconv.Atoi(usr.Gid)
+	if err != nil {
+		return fmt.Errorf("invalid gid: %v", err)
+	}
 
 	eu := os.Geteuid()
 	eg := os.Getegid()


### PR DESCRIPTION
Now that the *user.User is externally supplied we can't assume it's
a well-formed result of user.Lookup() as before.
