### PR TITLE
authorized_keys_d: replace asUser() with granular CGO implementations

### DIFF
--- a/src/authorized_keys_d/as_user/as_user.c
+++ b/src/authorized_keys_d/as_user/as_user.c
@@ -1,0 +1,202 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "as_user.h"
+
+// By doing these operations in CGO, we prevent the Go scheduler from
+// potentially executing while our uid/gid/umask is changed.
+//
+// By doing them in a new !CLONE_FS thread we also localize the effects of the
+// umask() switching.
+//
+// The calling go code must supply the appropriate args struct.
+// We create a new thread passing the args down verbatim, it's all fairly
+// mechanical.  There's no need to restore umask/eids since we just exit the
+// created thread when done.
+//
+// The return value and errno is simply fed back to the caller from the thread
+// through some variables in ctxt.  Synchronization is achieved via waitpid().
+
+#define STACK_SIZE (64 * 1024)
+
+typedef struct au_thread_ctxt {
+	au_ids_t	*ids;
+
+	void		*stack;
+	int		(*fn)(void *);
+	void		*fn_args;
+
+	int		ret;
+	int		err;
+} au_thread_ctxt_t;
+
+/* set_eids() sets the effective gid and uid of the calling thread to ids */
+static int set_eids(au_ids_t *ids) {
+	uid_t	cu;
+	gid_t	cg;
+
+	umask(077);
+
+	cu = geteuid();
+	cg = getegid();
+
+	if(cg != ids->gid && setregid(-1, ids->gid) == -1)
+		return -1;
+
+	if(cu != ids->uid && setreuid(-1, ids->uid) == -1)
+		return -1;
+
+	return 0;
+}
+
+/* in_thread_fn() switches users and calls ctxt->fn */
+static int in_thread_fn(au_thread_ctxt_t *ctxt) {
+	if((ctxt->ret = set_eids(ctxt->ids)) == 0)
+		ctxt->ret = ctxt->fn(ctxt->fn_args);
+
+	ctxt->err = errno;
+
+	return 0;
+}
+
+/* in_thread() calls in_thread_fn() in a new thread passing fn and args along in
+ * via an au_thread_ctxt_t.
+ */
+static int in_thread(au_ids_t *ids, int (*fn)(void *), void *fn_args) {
+	int			pid, ret = 0;
+	au_thread_ctxt_t	ctxt = {
+					.ids = ids,
+					.fn = fn,
+					.fn_args = fn_args,
+					.err = 0,
+					.ret = -1,
+				};
+	sigset_t		allsigs, orig;
+
+	if(!(ctxt.stack = malloc(STACK_SIZE))) {
+		ret = -1;
+		goto out;
+	}
+
+	/* It's necessary to block all signals before cloning, so the child
+	 * doesn't run any of the Go runtime's signal handlers.
+	 */
+	if((ret = sigemptyset(&orig)) == -1 ||
+	   (ret = sigfillset(&allsigs)) == -1)
+		goto out_stack;
+
+	if((ret = sigprocmask(SIG_BLOCK, &allsigs, &orig)) == -1)
+		goto out_stack;
+
+	pid = clone((int(*)(void *))in_thread_fn, ctxt.stack + STACK_SIZE,
+		    CLONE_FILES|CLONE_VM, &ctxt);
+
+	ret = sigprocmask(SIG_SETMASK, &orig, NULL);
+
+	if(pid != -1) {
+		if(waitpid(pid, NULL, __WCLONE) == -1 && errno != ECHILD) {
+			ret = -1;
+			goto out_stack;
+		}
+	} else {
+		ret = -1;
+	}
+
+	if(ret != -1) {
+		errno = ctxt.err;
+		ret = ctxt.ret;
+	}
+
+out_stack:
+	free(ctxt.stack);
+
+out:
+	return ret;
+}
+
+/* au_open() */
+static int au_open_fn(au_open_args_t *args) {
+	return open(args->path, args->flags, args->mode);
+}
+
+int au_open(au_open_args_t *args) {
+	return in_thread(&args->ids, (int(*)(void *))au_open_fn, args);
+}
+
+/* au_mkdir_all() */
+static int au_mkdir_all_fn(au_mkdir_all_args_t *args) {
+	int	ret = 0;
+	char	*sep, *dup;
+
+	/* TODO(vc): rewrite this, it's difficult to follow and probably buggy */
+
+	if(!*(args->path))
+		goto out;
+
+	if(!(dup = strdup(args->path))) {
+		ret = -1;
+		goto out;
+	}
+
+	for(sep = dup + 1; sep;) {
+		/* find next slash or end of path */
+		while(*sep && (*sep) != '/') sep++;
+		if(*sep)
+			*sep = '\0';
+		else
+			sep = NULL;
+
+		if(((ret = mkdir(dup, args->mode)) == -1) && errno != EEXIST)
+			goto out_free;
+
+		if(sep) {
+			/* restore the '/' and skip '/'s */
+			*sep = '/';
+			while(*sep && *sep == '/') sep++;
+		}
+	}
+
+	if(ret == -1 && errno == EEXIST)
+		ret = 0;
+
+out_free:
+	free(dup);
+
+out:
+	return ret;
+}
+
+int au_mkdir_all(au_mkdir_all_args_t *args) {
+	return in_thread(&args->ids, (int(*)(void *))au_mkdir_all_fn, args);
+}
+
+/* au_rename() */
+static int au_rename_fn(au_rename_args_t *args) {
+	return rename(args->oldpath, args->newpath);
+}
+
+int au_rename(au_rename_args_t *args) {
+	return in_thread(&args->ids, (int(*)(void *))au_rename_fn, args);
+}

--- a/src/authorized_keys_d/as_user/as_user.go
+++ b/src/authorized_keys_d/as_user/as_user.go
@@ -1,0 +1,98 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package as_user
+
+// #include "as_user.h"
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+)
+
+// TODO(vc): do this at akd.Open() and make our own typed user struct.
+// getIds extracts the uid and guid as integers from a user.User.
+func getIds(u *user.User) (C.int, C.int, error) {
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return -1, -1, fmt.Errorf("invalid uid: %v", err)
+	}
+
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return -1, -1, fmt.Errorf("invalid gid: %v", err)
+	}
+	return C.int(uid), C.int(gid), nil
+}
+
+// OpenFile reimplements os.OpenFile but switching euid/egid first if necessary.
+func OpenFile(u *user.User, name string, flags int, perm uint32) (*os.File, error) {
+	uid, gid, err := getIds(u)
+	if err != nil {
+		return nil, err
+	}
+	args := C.au_open_args_t{
+		ids:   C.au_ids_t{uid: uid, gid: gid},
+		path:  C.CString(name),
+		flags: C.uint(flags),
+		mode:  C.uint(perm),
+	}
+
+	fd, err := C.au_open(&args)
+	if fd < 0 {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+// MkdirAll reimplements os.MkdirAll but switching euid/egid first if necessary.
+func MkdirAll(u *user.User, path string, perm uint32) error {
+	uid, gid, err := getIds(u)
+	if err != nil {
+		return err
+	}
+	args := C.au_mkdir_all_args_t{
+		ids:  C.au_ids_t{uid: uid, gid: gid},
+		path: C.CString(path),
+		mode: C.uint(perm),
+	}
+
+	if ret, err := C.au_mkdir_all(&args); ret < 0 {
+		return err
+	}
+	return nil
+}
+
+// Rename reimplements os.Rename but switching euid/egid first if necessary.
+func Rename(u *user.User, oldpath, newpath string) error {
+	uid, gid, err := getIds(u)
+	if err != nil {
+		return err
+	}
+	args := C.au_rename_args_t{
+		ids:     C.au_ids_t{uid: uid, gid: gid},
+		oldpath: C.CString(oldpath),
+		newpath: C.CString(newpath),
+	}
+
+	if ret, err := C.au_rename(&args); ret < 0 {
+		return err
+	}
+	return nil
+}

--- a/src/authorized_keys_d/as_user/as_user.h
+++ b/src/authorized_keys_d/as_user/as_user.h
@@ -1,0 +1,41 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+typedef struct au_ids {
+	int	uid;
+	int	gid;
+} au_ids_t;
+
+typedef struct au_open_args {
+	au_ids_t	ids;
+	const char	*path;
+	unsigned int	flags;
+	unsigned int	mode;
+} au_open_args_t;
+
+typedef struct au_mkdir_all_args {
+	au_ids_t	ids;
+	const char	*path;
+	unsigned int	mode;
+} au_mkdir_all_args_t;
+
+typedef struct au_rename_args {
+	au_ids_t	ids;
+	const char	*oldpath;
+	const char	*newpath;
+} au_rename_args_t;
+
+int au_open(au_open_args_t *);
+int au_mkdir_all(au_mkdir_all_args_t *);
+int au_rename(au_rename_args_t *);

--- a/test
+++ b/test
@@ -2,7 +2,7 @@
 
 source ./build
 
-SRC="src authorized_keys_d"
+SRC="src authorized_keys_d authorized_keys_d/as_user"
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -s -l $SRC)


### PR DESCRIPTION
Since runtime.LockOSThread() doesn't prevent the Go scheduler from cloning
new threads from the locked thread, we can't safely switch thread-specific
properties like euid/egid without risk of them leaking into unlocked threads.

This commit instead uses CGO to wrap the filesystem operations in threads
where we can safely switch the euid/egid provided we don't call back into Go
from CGO.

The created threads are also !CLONE_FS, so we can privately umask() the
creates, without influencing the rest of the go process.
