### PR TITLE
authorized_keys_d: add missing includes

### DIFF
--- a/src/authorized_keys_d/as_user/as_user.c
+++ b/src/authorized_keys_d/as_user/as_user.c
@@ -14,6 +14,7 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdio.h>
@@ -21,6 +22,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "as_user.h"


### PR DESCRIPTION
Fixes implicit declaration warnings for open and waitpid
