### PR TITLE
authorized_keys_d: ensure newlines seperate keys

### DIFF
--- a/src/authorized_keys_d/authorized_keys_d.go
+++ b/src/authorized_keys_d/authorized_keys_d.go
@@ -318,6 +318,7 @@ func (akd *SSHAuthorizedKeysDir) Sync() error {
 			if err != nil {
 				return err
 			}
+			kb = append(kb, '\n')
 			if _, err := sf.Write(kb); err != nil {
 				return err
 			}

--- a/src/authorized_keys_d/authorized_keys_d_test.go
+++ b/src/authorized_keys_d/authorized_keys_d_test.go
@@ -488,6 +488,7 @@ func TestSync(t *testing.T) {
 			return
 		}
 		bytes = append(bytes, b...)
+		bytes = append(bytes, '\n')
 	}
 
 	if err := akd.Sync(); err != nil {


### PR DESCRIPTION
Before this change, two key files would be concatenated without any newline in
between. This usually wasn't a problem since key files tended to be
newline-terminated.
