### PR TITLE
src,test: Use package name rather than symlink to pkg

### DIFF
--- a/authorized_keys_d
+++ b/authorized_keys_d
@@ -1,1 +1,0 @@
-src/authorized_keys_d

--- a/src/authorized_keys_d/authorized_keys_d.go
+++ b/src/authorized_keys_d/authorized_keys_d.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/coreos/update-ssh-keys/authorized_keys_d/as_user"
+	"github.com/coreos/update-ssh-keys/src/authorized_keys_d/as_user"
 )
 
 const (

--- a/src/main.go
+++ b/src/main.go
@@ -23,7 +23,7 @@ import (
 	"os/user"
 	"strings"
 
-	keys "github.com/coreos/update-ssh-keys/authorized_keys_d"
+	keys "github.com/coreos/update-ssh-keys/src/authorized_keys_d"
 )
 
 var (

--- a/test
+++ b/test
@@ -2,7 +2,7 @@
 
 source ./build
 
-SRC="src authorized_keys_d authorized_keys_d/as_user"
+SRC="src src/authorized_keys_d src/authorized_keys_d/as_user"
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -s -l $SRC)


### PR DESCRIPTION
* Go vendor tools don't play well with packages structured to import via relative symlinks when vendored

rel: https://github.com/coreos/ignition/pull/387