### PR TITLE
readme: updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # `update-ssh-keys`
 
-`update-ssh-keys` fulfills two purposes. One, it is a library which performs the
-same function as the `authorized_keys_d` library in
-`github.com/coreos/update-ssh-keys`, except for rust instead. Two, it aims to
-replace the shell script called `update-ssh-keys` which exists in Container
-Linux currently with a rust binary that respects the lock files. It needs to
-play nice with the existing go implementation, which is currently used in
-ignition and the golang coreos-metadata.
+`update-ssh-keys` is a command line tool and a library for managing openssh
+authorized public keys. It keeps track of sets of keys with names, allows for
+adding additional keys, as well as deleting and disabling them. For usage
+information, see `update-ssh-keys -h` or run `cargo doc` to read the
+documentation on the library api. 
+
+The `update-ssh-keys` command line tool is included in Container Linux, so there
+should be no reason to install it. If you would like to use this on a
+non-Container Linux machine, you can build the project with `cargo build
+--release`. The rust toolchain is required to build it. You can install `rustup`
+to manage your rust toolchain - https://www.rustup.rs. 
+
+`test/test_update_ssh_keys.py` is a python script which tests the functionality
+of the `update-ssh-keys` command line tool. If changes are made to
+`update-ssh-keys`, that script should be run.


### PR DESCRIPTION
now that the project is in a stable state, the readme should reflect the
fact that it is now the defacto implementation of update-ssh-keys, not
an up-and-coming replacement for what used to be in this repository.