### PR TITLE
cargo: rustdoc library only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,14 @@ fs2 = "0.4"
 openssh-keys = "0.1"
 users = "0.6"
 
+[[bin]]
+name = "update-ssh-keys"
+path = "src/main.rs"
+doc = false
+
+[lib]
+path = "src/lib.rs"
+doc = true
+
 [profile.release]
 lto = true


### PR DESCRIPTION
This makes targets explicit in Cargo manifest, and disables documentation
for the binary target. It is currently required to make plain `cargo doc`
work for the library part, as current cargo cannot generate docs for two
targets with the same name.