### PR TITLE
tests: wire old python testsuite into cargo tests

### DIFF
--- a/tests/compat_python.rs
+++ b/tests/compat_python.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::process::Command;
+
+// This runs the old python integration test-suite to ensure
+// retro-compatibility.
+#[test]
+fn test_compat_python_suite() {
+    let pytests = env::current_dir().unwrap()
+        .join("tests")
+        .join("test_update_ssh_keys.py");
+    let result = Command::new(pytests).output().unwrap();
+    if !result.status.success() {
+        panic!(format!(
+            "\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&result.stdout),
+            String::from_utf8_lossy(&result.stderr)
+        ));
+    };
+    assert!(result.status.success());
+}

--- a/tests/test_update_ssh_keys.py
+++ b/tests/test_update_ssh_keys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2
 # Copyright 2017 CoreOS, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This adds some gluing logic in order to let `cargo test` also run the
existing python testsuite.