### PR TITLE
version: bump to v0.1.1

### DIFF
--- a/.github/tailor.yaml
+++ b/.github/tailor.yaml
@@ -7,4 +7,4 @@ rules:
   - name: commit description
     description: all commits must have a description with each line having no more than 72 characters
     expression: |-
-      .commits all((.description lines all(. length < 73) and (.description lines length > 0)) or (.title test "^Revert") or (.title test "^news"))
+      .commits all((.description lines all(. length < 73) and (.description lines length > 0)) or (.title test "^Revert") or (.title test "^news") or (.title test "^version"))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "update-ssh-keys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 
 [dependencies]


### PR DESCRIPTION
Release notes draft:
* updated `openssh-keys` library dependency version to v0.2.0. This fixes an issue where authorized_keys file options were not respected (#20, coreos/bugs#2229, sdemos/openssh-keys#7)