### PR TITLE
lib: warn and omit invalid public keys

### DIFF
--- a/tests/test_update_ssh_keys.py
+++ b/tests/test_update_ssh_keys.py
@@ -225,9 +225,9 @@ class UpdateSshKeysTestCase(unittest.TestCase):
         self.test_add_one_file()
         proc = self.run_script('-a', 'bad', self.pub_files['bad'])
         out, err = proc.communicate()
-        self.assertEquals(proc.returncode, 1)
-        self.assertNotIn('Updated', out)
-        self.assertIn('failed to parse public key', err)
+        self.assertEquals(proc.returncode, 0)
+        self.assertIn('warning', out)
+        self.assertIn('failed to parse public key', out)
         self.assertHasKeys('valid1')
 
 


### PR DESCRIPTION
when update-ssh-keys finds an invalid key in the authorized_keys
directory, it would throw an error and quit. this is a different
behavior than the shell script, which didn't do any validation on the
contents of the authorized_keys directory. this commit reimplements the
read_keys function that is in the openssh-keys library with a slight
change; instead of returning an error when the parse fails, it prints
out a warning and omits the key from authorized keys. this is also a
different behavior, but it brings in line the validation present in this
version with the not-crashing of the shell script.

one possible problem with this implementation is that when it finds an
invalid key, it will remove it entirely, from both the authorized_keys
file and the authorized_keys directory, which means it will effectively
only warn the first time it finds an invalid key and not after. changing
the implementation to keep the invalid key in any way would require a
more significant restructuring, since constructing the in-memory
representation of the keys implicitly validates them.

fixes coreos/bugs#2283

/cc @bgilbert @crawford @dgonyeo @lucab 