### PR TITLE
travis: build on minimum toolchain too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: rust
 
 rust:
+  - 1.26.0              # minimum supported toolchain
+  - nightly-2017-10-08  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
-  - nightly-2017-10-08
 
 matrix:
   allow_failures:
@@ -13,14 +14,15 @@ matrix:
 env:
   global:
     - CLIPPY_VERSION=0.0.165
+    - CLIPPY_RUST_VERSION=nightly-2017-10-08
 
 before_script:
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2017-10-08" ]]; then
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
       cargo install clippy --vers $CLIPPY_VERSION --force;
     fi'
 
 script:
   - cargo test
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2017-10-08" ]]; then
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
       cargo clippy -- -D warnings;
     fi'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# `update-ssh-keys`
+# update-ssh-keys
+
+[![Build Status](https://travis-ci.org/coreos/update-ssh-keys.svg?branch=master)](https://travis-ci.org/coreos/update-ssh-keys)
+![minimum rust 1.26](https://img.shields.io/badge/rust-1.26%2B-orange.svg)
 
 `update-ssh-keys` is a command line tool and a library for managing openssh
 authorized public keys. It keeps track of sets of keys with names, allows for


### PR DESCRIPTION
This checks that master and further PRs won't break on older
toolchains used by downstream distributions (pinning to 1.26 for
historical ContainerLinux compatibility).