### PR TITLE
travis: bump minimum supported toolchain to 1.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.26.0              # minimum supported toolchain
+  - 1.28.0              # minimum supported toolchain
   - nightly-2018-07-24  # pinned toolchain for clippy
   - stable
   - beta


### PR DESCRIPTION
https://github.com/coreos/coreos-overlay/pull/3378

/cc: @lucab 