### PR TITLE
cargo: minor bump for public API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "update-ssh-keys"
-version = "0.4.2-alpha.0"
+version = "0.5.0-alpha.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 repository = "https://github.com/coreos/update-ssh-keys"
 documentation = "https://docs.rs/update-ssh-keys"
 description = "A tool for managing authorized SSH keys"
-version = "0.4.2-alpha.0"
+version = "0.5.0-alpha.0"
 
 [dependencies]
 # Private dependencies.


### PR DESCRIPTION
This bumps the minor version after `users` update.