### PR TITLE
travis: update clippy to latest stable toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 rust:
   - 1.31.0  # minimum supported toolchain
-  - 1.34.0  # pinned toolchain for clippy
+  - 1.37.0  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.34.0
+    - CLIPPY_RUST_VERSION=1.37.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then


### PR DESCRIPTION
This updates Travis clippy job to use Rust toolchain 1.37.0.