### PR TITLE
ci: bump linting and minimum toolchain in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 
 rust:
-  - 1.36.0  # minimum supported toolchain
-  - 1.37.0  # pinned toolchain for clippy
+  - 1.43.0  # minimum supported toolchain
+  - 1.47.0  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.37.0
+    - CLIPPY_RUST_VERSION=1.47.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # update-ssh-keys
 
 [![Build Status](https://travis-ci.org/coreos/update-ssh-keys.svg?branch=master)](https://travis-ci.org/coreos/update-ssh-keys)
-![minimum rust 1.31](https://img.shields.io/badge/rust-1.31%2B-orange.svg)
+![minimum rust 1.43](https://img.shields.io/badge/rust-1.43%2B-orange.svg)
 
 `update-ssh-keys` is a command line tool and a library for managing openssh
 authorized public keys. It keeps track of sets of keys with names, allows for


### PR DESCRIPTION
This bumps the minimum supported toolchain to 1.43, and linting
toolchain to latest stable.